### PR TITLE
Rename systemd-check

### DIFF
--- a/templates/commands.conf.j2
+++ b/templates/commands.conf.j2
@@ -476,7 +476,7 @@ object CheckCommand "cst_pgsql" {
   vars.my_login = "$credentials$"
 }
 
-object CheckCommand "systemd2" {
+object CheckCommand "custom-systemd" {
   import "plugin-check-command"
   command = [PluginDir + "/check_systemd_service.sh"]
 

--- a/templates/commands.conf.j2
+++ b/templates/commands.conf.j2
@@ -476,7 +476,7 @@ object CheckCommand "cst_pgsql" {
   vars.my_login = "$credentials$"
 }
 
-object CheckCommand "systemd" {
+object CheckCommand "systemd2" {
   import "plugin-check-command"
   command = [PluginDir + "/check_systemd_service.sh"]
 


### PR DESCRIPTION
The new version of icinga2 adds an own CheckCommand with the name "systemd", making icinga not start if the custom systemd-check of this role is used (since the CheckCommand "systemd" then is defined twice).
This PR renames the custom systemd-check so that the role can be used with the same ansible-configuration as before.